### PR TITLE
Do not manage named.conf by default.

### DIFF
--- a/manifests/control/config.pp
+++ b/manifests/control/config.pp
@@ -24,6 +24,7 @@ class contrail::control::config (
   $secret,
   $forwarder              = '8.8.8.8',
   $dns_config             = {},
+  $manage_named_conf      = false,
   $control_config         = {},
   $control_nodemgr_config = {},
 ) {
@@ -51,9 +52,10 @@ class contrail::control::config (
     $forwarders_option = ''
   }
 
-  file { '/etc/contrail/dns/contrail-named.conf' :
-    ensure  => file,
-    content => template('contrail/contrail-named.conf.erb'),
+  if $manage_named_conf {
+    file { '/etc/contrail/dns/contrail-named.conf' :
+      ensure  => file,
+      content => template('contrail/contrail-named.conf.erb'),
+    }
   }
-
 }


### PR DESCRIPTION
Do not manage named_conf by default as contrail-dns insists on rewriting the file at every time, resulting in a food fight with puppet.