### PR TITLE
Python path is not correctly set in some manifests

### DIFF
--- a/manifests/control/provision_control.pp
+++ b/manifests/control/provision_control.pp
@@ -64,6 +64,7 @@ class contrail::control::provision_control (
   }
 
   exec { "provision_control.py ${control_node_name}" :
+    path => '/usr/bin',
     command => "python /opt/contrail/utils/provision_control.py \
                  --host_name ${control_node_name} \
                  --host_ip ${control_node_address} \

--- a/manifests/control/provision_encap.pp
+++ b/manifests/control/provision_encap.pp
@@ -52,6 +52,7 @@ class contrail::control::provision_encap (
 ) {
 
   exec { "provision_encap.py ${api_address}" :
+    path => '/usr/bin',
     command => "python /opt/contrail/utils/provision_encap.py \
                  --api_server_ip ${api_address} \
                  --api_server_port ${api_port} \

--- a/manifests/control/provision_linklocal.pp
+++ b/manifests/control/provision_linklocal.pp
@@ -67,6 +67,7 @@ class contrail::control::provision_linklocal (
 ) {
 
   exec { "provision_linklocal.py ${api_address}" :
+    path => '/usr/bin',
     command => "python /opt/contrail/utils/provision_linklocal.py \
                  --api_server_ip ${api_address} \
                  --api_server_port ${api_port} \

--- a/manifests/vrouter/config.pp
+++ b/manifests/vrouter/config.pp
@@ -98,6 +98,7 @@ class contrail::vrouter::config (
   }
 
   exec { '/bin/python /opt/contrail/utils/update_dev_net_config_files.py' :
+    path => '/usr/bin',
     command => "/bin/python /opt/contrail/utils/update_dev_net_config_files.py \
                  --vhost_ip ${vhost_ip} \
                  --dev ${device} \

--- a/manifests/vrouter/provision_vrouter.pp
+++ b/manifests/vrouter/provision_vrouter.pp
@@ -48,6 +48,7 @@ class contrail::vrouter::provision_vrouter (
 ) {
 
   exec { "provision_vrouter.py ${node_name}" :
+    path => '/usr/bin',
     command => "python /opt/contrail/utils/provision_vrouter.py \
                  --host_name ${node_name} \
                  --host_ip ${node_address} \


### PR DESCRIPTION
This pull request is to complete the proposed work in pull #14

It adds a `path => '/usr/bin'` key / value in each section where
the python binary is called. This addition is to insure systems
can locate the python binary in the current POSIX path.