### PR TITLE
Parameterize vgw*, fix the overall workflow for vrouter deployments on compute.

### DIFF
--- a/manifests/qemu.pp
+++ b/manifests/qemu.pp
@@ -17,9 +17,9 @@
 #   (optional) cgroup_device_acl setting for qemu
 #
 class contrail::qemu (
-  $qemu_user = ‘“root”’,
-  $qemu_group = ‘”root”’,
-  $qemu_clear_emulator_capabilities = ‘0’,
+  $qemu_user = '\“root\”',
+  $qemu_group = '\”root\”',
+  $qemu_clear_emulator_capabilities = '0',
   $qemu_cgroup_device_acl = '[ "/dev/null", "/dev/full", "/dev/zero", "/dev/random", "/dev/urandom", "/dev/ptmx", "/dev/kvm", "/dev/kqemu", "/dev/rtc", "/dev/hpet", "/dev/net/tun",]',
 ) {
 

--- a/manifests/qemu.pp
+++ b/manifests/qemu.pp
@@ -17,8 +17,8 @@
 #   (optional) cgroup_device_acl setting for qemu
 #
 class contrail::qemu (
-  $qemu_user = '\“root\”',
-  $qemu_group = '\”root\”',
+  $qemu_user = '“root”',
+  $qemu_group = '”root”',
   $qemu_clear_emulator_capabilities = '0',
   $qemu_cgroup_device_acl = '[ "/dev/null", "/dev/full", "/dev/zero", "/dev/random", "/dev/urandom", "/dev/ptmx", "/dev/kvm", "/dev/kqemu", "/dev/rtc", "/dev/hpet", "/dev/net/tun",]',
 ) {

--- a/manifests/qemu.pp
+++ b/manifests/qemu.pp
@@ -17,8 +17,8 @@
 #   (optional) cgroup_device_acl setting for qemu
 #
 class contrail::qemu (
-  $qemu_user = '“root”',
-  $qemu_group = '”root”',
+  $qemu_user = '"root"',
+  $qemu_group = '"root"',
   $qemu_clear_emulator_capabilities = '0',
   $qemu_cgroup_device_acl = '[ "/dev/null", "/dev/full", "/dev/zero", "/dev/random", "/dev/urandom", "/dev/ptmx", "/dev/kvm", "/dev/kqemu", "/dev/rtc", "/dev/hpet", "/dev/net/tun",]',
 ) {

--- a/manifests/qemu.pp
+++ b/manifests/qemu.pp
@@ -1,0 +1,40 @@
+# == Class: contrail::qemu
+#
+# Update qemu settings
+#
+# === Parameters:
+#
+# [*qemu_user*]
+#   (optional) username for qemu
+#
+# [*qemu_group*]
+#   (optional) group for qemu
+#
+# [*qemu_clear_emulator_capabilities*]
+#   (optional) clear_emulator_capabilities setting for qemu
+#
+# [*qemu_cgroup_device_acl*]
+#   (optional) cgroup_device_acl setting for qemu
+#
+class contrail::qemu (
+  $qemu_user = ‘“root”’,
+  $qemu_group = ‘”root”’,
+  $qemu_clear_emulator_capabilities = ‘0’,
+  $qemu_cgroup_device_acl = '[ "/dev/null", "/dev/full", "/dev/zero", "/dev/random", "/dev/urandom", "/dev/ptmx", "/dev/kvm", "/dev/kqemu", "/dev/rtc", "/dev/hpet", "/dev/net/tun",]',
+) {
+
+  $ini_defaults = { 
+    'path' => '/etc/libvirt/qemu.conf', 
+    notify => Service['libvirtd'],
+  }
+  $qemuconf = { 
+    '' => {
+      'user' => $qemu_user,
+      'group' => $qemu_group,
+      'clear_emulator_capabilities' => $qemu_clear_emulator_capabilities,
+      'cgroup_device_acl' => $qemu_cgroup_device_acl,
+    }
+  }
+  create_ini_settings($qemuconf, $ini_defaults)
+
+}

--- a/manifests/vrouter.pp
+++ b/manifests/vrouter.pp
@@ -14,7 +14,8 @@ class contrail::vrouter (
   anchor {'contrail::vrouter::start': } ->
   class {'::contrail::vrouter::install': } ->
   class {'::contrail::vrouter::config': } ~>
-  class {'::contrail::vrouter::service': }
+  class {'::contrail::vrouter::service': } ->
+  class {'::contrail::vrouter::provision_vrouter': }
   anchor {'contrail::vrouter::end': }
   
 }

--- a/manifests/vrouter.pp
+++ b/manifests/vrouter.pp
@@ -15,7 +15,8 @@ class contrail::vrouter (
   class {'::contrail::vrouter::install': } ->
   class {'::contrail::vrouter::config': } ~>
   class {'::contrail::vrouter::service': } ->
-  class {'::contrail::vrouter::provision_vrouter': }
+  class {'::contrail::vrouter::provision_vrouter': } ->
+  class {'::contrail::qemu': }
   anchor {'contrail::vrouter::end': }
   
 }

--- a/manifests/vrouter/config.pp
+++ b/manifests/vrouter/config.pp
@@ -130,7 +130,8 @@ class contrail::vrouter::config (
     onlyif  => [ "grep IPADDR /etc/sysconfig/network-scripts/ifcfg-${compute_device}",
                  "ls /etc/sysconfig/network-scripts/ifcfg-${compute_device}.contrailsave",
                  "ls /etc/sysconfig/network-scripts/ifcfg-vhost0" ],
-    logoutput => true
+    logoutput => true,
+    notify => Exec['restart network devices'],
   }
 
   exec { 'restart network devices':
@@ -140,8 +141,7 @@ class contrail::vrouter::config (
                 ifdown ${compute_device} && \
                 ifup ${compute_device} && \
                 systemctl start supervisor-vrouter",
-    unless  => "ping -c3 ${discovery_ip}",
-    #unless  => "ping -c3 8.8.8.9",
+    #unless  => "ping -c3 ${discovery_ip}",
     logoutput => true
   }
 }

--- a/manifests/vrouter/config.pp
+++ b/manifests/vrouter/config.pp
@@ -144,18 +144,5 @@ class contrail::vrouter::config (
     logoutput => true
   }
 
-  $ini_defaults = { 
-    'path' => '/etc/libvirt/qemu.conf', 
-     notify => Service['libvirtd'],
-  }
-  $qemuconf = { 
-    '' => {
-      'user' => '"root"',
-      'group' => '"root"',
-      'clear_emulator_capabilities' => '0',
-      'cgroup_device_acl' => '[ "/dev/null", "/dev/full", "/dev/zero", "/dev/random", "/dev/urandom", "/dev/ptmx", "/dev/kvm", "/dev/kqemu", "/dev/rtc", "/dev/hpet", "/dev/net/tun",]',
-    }
-  }
-  create_ini_settings($qemuconf, $ini_defaults)
 
 }

--- a/manifests/vrouter/config.pp
+++ b/manifests/vrouter/config.pp
@@ -108,7 +108,7 @@ class contrail::vrouter::config (
 
   exec { 'update-net-config':
     path    => [ '/usr/bin', '/usr/sbin', '/bin', '/sbin', ],
-    command => "/opt/contrail/utils/update_dev_net_config_files.py \
+    command => "python /opt/contrail/utils/update_dev_net_config_files.py \
                  --vhost_ip ${ip_to_steal} \
                  --dev ${device} \
                  --compute_dev ${device} \

--- a/templates/vrouter/agent_param.erb
+++ b/templates/vrouter/agent_param.erb
@@ -6,6 +6,6 @@ pname=contrail-vrouter-agent
 LIBDIR=/usr/lib64
 VHOST_CFG=/etc/sysconfig/network-scripts/ifcfg-vhost0
 dev=<%= @device %>
-vgw_subnet_ip=<% @vgw_public_subnet %>
-vgw_int=<% @vgw_interface %>
+vgw_subnet_ip=<%= @vgw_public_subnet %>
+vgw_int=<%= @vgw_interface %>
 LOGFILE=/var/log/contrail/vrouter.log

--- a/templates/vrouter/agent_param.erb
+++ b/templates/vrouter/agent_param.erb
@@ -6,6 +6,6 @@ pname=contrail-vrouter-agent
 LIBDIR=/usr/lib64
 VHOST_CFG=/etc/sysconfig/network-scripts/ifcfg-vhost0
 dev=<%= @device %>
-vgw_subnet_ip=
-vgw_int=
-LOGFILE=--log-file=/var/log/contrail/vrouter.log
+vgw_subnet_ip=<% @vgw_public_subnet %>
+vgw_int=<% @vgw_interface %>
+LOGFILE=/var/log/contrail/vrouter.log


### PR DESCRIPTION
vrouter deployment workflow was not working as intended. This change allows for cleaner vrouter maintenance during the triple lifecycle and minimizes traffic interruptions.

os-net-config currently will manage the eth* config files regardless of if there is an update to the system. This change ensures that the vrouter modifications to these files stay in place after a deploy/update.

Additionally there are fixes to some variables which are in fact parameters that need to be evaluated in puppet before being passed to an exec. This is handled by editing the $vrouter_agent_config hash to update their key.

Many thanks to Nagendra Prasath & Mike Orazi for their significant contributions to this work and testing. Significant portions of the code included in the change is from them.