### PR TITLE
Create rspec tests for puppet classes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
   gem 'puppetlabs_spec_helper',                :require => false
-  gem 'rspec-puppet', '2.2.0',                 :require => false
+  gem 'rspec-puppet', ['~> 2.2.0'],            :require => false
+  gem 'rspec-puppet-facts', ['>= 1.7.0'],      :require => false
   gem 'puppet-blacksmith',                     :require => false
   gem 'puppet-lint-param-docs',                :require => false
   gem 'puppet-lint-absolute_classname-check',  :require => false
@@ -23,6 +24,8 @@ group :development, :unit_tests do
 end
 
 group :system_tests do
+  # beaker > 3.0.0 requires newer versions of ruby
+  gem 'beaker', ['< 3.0.0'],           :require => false
   gem 'beaker-rspec',                  :require => false
   gem 'beaker-puppet_install_helper',  :require => false
 end

--- a/spec/classes/contrail_analytics_spec.rb
+++ b/spec/classes/contrail_analytics_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::analytics' do
+  shared_examples 'contrail::analytics' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::analytics') }
+      it { is_expected.to contain_anchor('contrail::analytics::start') }
+      it { is_expected.to contain_class('contrail::analytics::install') }
+      it { is_expected.to contain_class('contrail::analytics::config') }
+      it { is_expected.to contain_class('contrail::analytics::service') }
+      it { is_expected.to contain_anchor('contrail::analytics::end') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      it_behaves_like 'contrail::analytics'
+    end
+  end
+end

--- a/spec/classes/contrail_config_spec.rb
+++ b/spec/classes/contrail_config_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::config' do
+  shared_examples 'contrail::config' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::config') }
+      it { is_expected.to contain_anchor('contrail::config::start') }
+      it { is_expected.to contain_class('contrail::config::install') }
+      it { is_expected.to contain_class('contrail::config::config') }
+      it { is_expected.to contain_class('contrail::config::service') }
+      it { is_expected.to contain_anchor('contrail::config::end') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      it_behaves_like 'contrail::config'
+    end
+  end
+end

--- a/spec/classes/contrail_control_spec.rb
+++ b/spec/classes/contrail_control_spec.rb
@@ -1,0 +1,38 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::control' do
+  shared_examples 'contrail::control' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::control') }
+      it { is_expected.to contain_anchor('contrail::control::start') }
+      it { is_expected.to contain_class('contrail::control::install') }
+      it { is_expected.to contain_class('contrail::control::config') }
+      it { is_expected.to contain_class('contrail::control::service') }
+      it { is_expected.to contain_anchor('contrail::control::end') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      # TODO: there's a required param for contrail::control::config...
+      #it_behaves_like 'contrail::control'
+    end
+  end
+end

--- a/spec/classes/contrail_ctrl_details_spec.rb
+++ b/spec/classes/contrail_ctrl_details_spec.rb
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::ctrl_details' do
+  shared_examples 'contrail::ctrl_details' do
+    context 'with default parameters' do
+      it { is_expected.to contain_class('contrail::ctrl_details') }
+      it { is_expected.to contain_file('/etc/contrail/ctrl-details').with(
+        :ensure => 'file').with_content("SERVICE_TOKEN=
+AUTH_PROTOCOL=http
+ADMIN_TOKEN=password
+CONTROLLER=127.0.0.1
+AMQP_SERVER=127.0.0.1
+COMPUTE=127.0.0.1
+CONTROLLER_MGMT=127.0.0.1
+INTERNAL_VIP=127.0.0.1
+CONTRAIL_INTERNAL_VIP=127.0.0.1
+EXTERNAL_VIP=127.0.0.1
+")
+      }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    it_behaves_like 'contrail::ctrl_details'
+  end
+end

--- a/spec/classes/contrail_database_spec.rb
+++ b/spec/classes/contrail_database_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::database' do
+  shared_examples 'contrail::database' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::database') }
+      it { is_expected.to contain_anchor('contrail::database::start') }
+      it { is_expected.to contain_class('contrail::database::install') }
+      it { is_expected.to contain_class('contrail::database::config') }
+      it { is_expected.to contain_class('contrail::database::service') }
+      it { is_expected.to contain_anchor('contrail::database::end') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      it_behaves_like 'contrail::database'
+    end
+  end
+end

--- a/spec/classes/contrail_init_spec.rb
+++ b/spec/classes/contrail_init_spec.rb
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail' do
+  shared_examples 'contrail' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    it_behaves_like 'contrail'
+  end
+end

--- a/spec/classes/contrail_keystone_spec.rb
+++ b/spec/classes/contrail_keystone_spec.rb
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::keystone' do
+  shared_examples 'contrail::keystone' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::keystone') }
+    end
+
+    context 'with some keystone settings' do
+      let (:params) do
+        { :keystone_config => {
+            'FOO/bar' => { 'value' => 'something' }
+          }
+        }
+      end
+
+      it { is_expected.to contain_contrail_keystone_config('FOO/bar').with_value('something') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      it_behaves_like 'contrail::keystone'
+    end
+  end
+end

--- a/spec/classes/contrail_params_spec.rb
+++ b/spec/classes/contrail_params_spec.rb
@@ -1,0 +1,30 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::params' do
+  shared_examples 'contrail::params' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::params') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    it_behaves_like 'contrail::params'
+  end
+end

--- a/spec/classes/contrail_provision_control_spec.rb
+++ b/spec/classes/contrail_provision_control_spec.rb
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::provision_control' do
+  shared_examples 'contrail::provision_control' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::provision_control') }
+      it { is_expected.to contain_class('contrail::control::provision_control') }
+      it { is_expected.to contain_class('contrail::control::provision_linklocal') }
+      it { is_expected.to contain_class('contrail::control::provision_encap') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    it_behaves_like 'contrail::provision_control'
+  end
+end

--- a/spec/classes/contrail_service_token_spec.rb
+++ b/spec/classes/contrail_service_token_spec.rb
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::service_token' do
+  shared_examples 'contrail::service_token' do
+    context 'with default parameters' do
+      it { is_expected.to contain_class('contrail::service_token') }
+      it { is_expected.to contain_file('/etc/contrail/service.token').with(
+        :ensure => 'file',
+        :content => '', )
+      }
+    end
+
+    context 'with a service token' do
+      let (:params) do
+        { :keystone_service_token => 'atoken' }
+      end
+      it { is_expected.to contain_file('/etc/contrail/service.token').with(
+        :ensure => 'file',
+        :content => 'atoken', )
+      }
+    end
+
+  end
+
+  on_supported_os.each do |os, facts|
+    it_behaves_like 'contrail::service_token'
+  end
+end

--- a/spec/classes/contrail_vnc_api_spec.rb
+++ b/spec/classes/contrail_vnc_api_spec.rb
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::vnc_api' do
+  shared_examples 'contrail::vnc_api' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::vnc_api') }
+    end
+
+    context 'with some vnc_api settings' do
+      let (:params) do
+        { :vnc_api_config => {
+            'FOO/bar' => { 'value' => 'something' }
+          }
+        }
+      end
+
+      it { is_expected.to contain_contrail_vnc_api_config('FOO/bar').with_value('something') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      it_behaves_like 'contrail::vnc_api'
+    end
+  end
+end

--- a/spec/classes/contrail_vrouter_spec.rb
+++ b/spec/classes/contrail_vrouter_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::vrouter' do
+  shared_examples 'contrail::vrouter' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::vrouter') }
+      it { is_expected.to contain_anchor('contrail::vrouter::start') }
+      it { is_expected.to contain_class('contrail::vrouter::install') }
+      it { is_expected.to contain_class('contrail::vrouter::config') }
+      it { is_expected.to contain_class('contrail::vrouter::service') }
+      it { is_expected.to contain_anchor('contrail::vrouter::end') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      it_behaves_like 'contrail::vrouter'
+    end
+  end
+end

--- a/spec/classes/contrail_webui_spec.rb
+++ b/spec/classes/contrail_webui_spec.rb
@@ -1,0 +1,37 @@
+#
+# Copyright (C) 2016 Red Hat Inc. <licensing@redhat.com>
+#
+# Author: Alex Schultz <aschultz@redhat.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+require 'spec_helper'
+
+describe 'contrail::webui' do
+  shared_examples 'contrail::webui' do
+    context 'with default paramters' do
+      it { is_expected.to contain_class('contrail::webui') }
+      it { is_expected.to contain_anchor('contrail::webui::start') }
+      it { is_expected.to contain_class('contrail::webui::install') }
+      it { is_expected.to contain_class('contrail::webui::config') }
+      it { is_expected.to contain_class('contrail::webui::service') }
+      it { is_expected.to contain_anchor('contrail::webui::end') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      it_behaves_like 'contrail::webui'
+    end
+  end
+end

--- a/spec/classes/skel_spec.rb
+++ b/spec/classes/skel_spec.rb
@@ -1,1 +1,0 @@
-require 'spec_helper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,15 @@
 #
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'shared_examples'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts
 
 RSpec.configure do |c|
   c.alias_it_should_behave_like_to :it_configures, 'configures'
   c.alias_it_should_behave_like_to :it_raises, 'raises'
+
+  # custom facts for rspec-puppet-facts
+  add_custom_fact :puppetversion, Puppet.version
 end
 
 at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
In addition to the unit tests for the providers, the contrail module
should also have rspec tests for the puppet classes themselves. This is
a starting point for the rspec tests as well as introducing
rspec-puppet-facts to properly test the supported OS configurations.